### PR TITLE
`aws-lambda-binary` runs any binary on AWS Lambda

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ _Tools that aren't quite frameworks, but are intended for getting your Go code e
 
 [Node.js handler for Go in Lambda](https://gist.github.com/miksago/d1c456d4e235e025791d) - Another way to run Go in AWS Lambda
 
+[AWS Lambda Binary](https://www.npmjs.com/package/aws-lambda-binary) - Run any compiled binary on AWS Lambda over standard input and output for maximum flexibility. 5 lines of code to get started with your lambda.
+
 ## Examples & Demos
 
 [go-lambda-geoip](https://github.com/tmaiaroto/go-lambda-geoip) - An example using Node.js to call Go in AWS Lambda to retrieve the requester's IP -> geolocation via API Gateway


### PR DESCRIPTION
This package is just a wrapper over spawning a compiled binary process, and communicate with it over **stdio** for maximum flexibility and super fast latencies (sub-millisecond responses).

Can be used for any language that produces compiled binaries! Go, C, C++, Racket, OCaml, Rust, etc.